### PR TITLE
Add prompting the user for unlocking when unlocking the collection

### DIFF
--- a/lib/dbus_secrets.dart
+++ b/lib/dbus_secrets.dart
@@ -35,7 +35,7 @@ class DBusSecrets {
   // Unlock the keyring
   Future<bool> unlock() async {
     try {
-      await _client.callMethod(
+      var response = await _client.callMethod(
         destination: _service,
         path: DBusObjectPath(_path),
         interface: 'org.freedesktop.Secret.Service',
@@ -44,6 +44,41 @@ class DBusSecrets {
           DBusArray.objectPath([_collection]),
         ],
       );
+
+      // Check if the unlocking was successful
+      final objectPath = response.returnValues[1] as DBusObjectPath;
+      if (objectPath.value == "/") {
+        _isUnlocked = true;
+        return true;
+      }
+
+      // Create the listener to subscribe to the completed signal on the prompt
+      var promptRemote = DBusRemoteObject(_client, name: _service, path: objectPath);
+      var completedStream = DBusRemoteObjectSignalStream(
+        object: promptRemote,
+        interface: 'org.freedesktop.Secret.Prompt',
+        name: 'Completed',
+      );
+
+      // Wait a little bit to prevent a race condition between the subscription and the sending of the prompt call
+      Timer(Duration(milliseconds: 500), () {
+        _client.callMethod(
+          destination: _service,
+          path: objectPath,
+          interface: "org.freedesktop.Secret.Prompt",
+          name: "Prompt",
+          values: [DBusString('')],
+        );
+      });
+
+      // Wait for the completed signal
+      final signal = await completedStream.first;
+      final dismissed = (signal.values[0] as DBusBoolean).value;
+      if (dismissed) {
+        print("Unlock error: Prompt was dismissed by user.");
+        return false;
+      }
+      print("Unlock successful: Prompt was accepted by user.");
 
       _isUnlocked = true;
       return true;

--- a/lib/dbus_secrets.dart
+++ b/lib/dbus_secrets.dart
@@ -75,10 +75,8 @@ class DBusSecrets {
       final signal = await completedStream.first;
       final dismissed = (signal.values[0] as DBusBoolean).value;
       if (dismissed) {
-        print("Unlock error: Prompt was dismissed by user.");
         return false;
       }
-      print("Unlock successful: Prompt was accepted by user.");
 
       _isUnlocked = true;
       return true;


### PR DESCRIPTION
Hi, I've recently implemented your package in my app. Thanks for all of the amazing work you've done. As ``flutter_secure_storage`` is currently kind of broken on Linux, I needed an alternative and your package replaces the void for a secure storage provider on Linux pretty well.

However, when I tried using it on KDE Plasma it didn't work. After a bunch of investigation I noticed that KDE Wallet (the secrets provider for KDE Plasma) keeps asking for prompts even when nothing opens up.

This pull request adds additional functionality to the ``.unlock()`` method:
1. It checks if there is a prompt in the response from the ``Unlock`` call.
2. It listens to the ``Completed`` signal on the ``org.freedesktop.Secret.Prompt`` interface to later know if the prompt has been accepted or dismissed.
3. It makes a ``Prompt`` call on the ``org.freedesktop.Secret.Prompt`` interface to open the prompt. ``windowId`` is kept as ``''`` here because we don't know it.
4. After receiving the ``Completed`` signal it checks whether dismissed or actually completed and returns true or false based on that.

I hope this can be merged in and improve the experience with this package for KDE Plasma and also potentially other secret providers.